### PR TITLE
feat: Add admin dashboard for service management

### DIFF
--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Package } from 'lucide-react';
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarTrigger,
+} from '@/components/ui/sidebar';
+import { Button } from '@/components/ui/button';
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+
+  return (
+    <SidebarProvider>
+      <Sidebar>
+        <SidebarHeader>
+          {/* Placeholder for a logo or title */}
+          <h2 className="text-lg font-semibold">Admin</h2>
+          <SidebarTrigger />
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                isActive={pathname.startsWith('/services')}
+                tooltip="Dienstleistungen"
+              >
+                <Link href="/services">
+                  <Package />
+                  <span>Dienstleistungen</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarContent>
+      </Sidebar>
+      <SidebarInset>{children}</SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/app/(admin)/services/page.tsx
+++ b/app/(admin)/services/page.tsx
@@ -1,0 +1,32 @@
+import { getTenantScopedPrismaClient } from '@/lib/rls';
+import { requireRole } from '@/lib/auth';
+import { Service } from '@prisma/client';
+import { ServicesClient } from '@/components/admin/ServicesClient';
+import { Toaster } from '@/components/ui/sonner';
+
+async function getServices(): Promise<Service[]> {
+  try {
+    const { tenant } = await requireRole(['owner', 'admin']);
+    const prisma = getTenantScopedPrismaClient(tenant.id);
+    const services = await prisma.service.findMany({
+      orderBy: { name: 'asc' },
+    });
+    return services;
+  } catch (error) {
+    console.error('Failed to fetch services:', error);
+    // In case of auth error, requireRole will throw and Next.js will catch it.
+    // For other errors, return an empty array to avoid crashing the page.
+    return [];
+  }
+}
+
+export default async function ServicesPage() {
+  const services = await getServices();
+
+  return (
+    <>
+      <ServicesClient services={services} />
+      <Toaster />
+    </>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1369,15 +1369,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.0.tgz",
-      "integrity": "sha512-sDaprBAfzCQiOgo2pO+LhnV0Wt2wBgartjrr+dpcTORYVnnXD0gwhHhiiyIih9hQbq+JnbqH4odgcFWhqCGidw==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.2.tgz",
+      "integrity": "sha512-Qe06ew4zt12LeO6N7j8/nULSOe3fMXE4dM6xgpBQNvdzyK1sv5y4oAP3bq4LamrvGCZtmRYnW8URFCeX5nFgGg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.0.tgz",
-      "integrity": "sha512-v7Jj9iqC6enxIRBIScD/o0lH7QKvSxq2LM8UTyqJi+S2w2QzhMYjven4vgu/RzgsdtdbpkyCxBTzHl/gN5rTRg==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.2.tgz",
+      "integrity": "sha512-8bGt577BXGSd4iqFygmzIfTYizHb0LGWqH+qgIF/2EDxS5JsSdERJKA8WgwDyNBZgTIIA4D8qUtoQHmxIIquoQ==",
       "cpu": [
         "arm64"
       ],
@@ -1391,9 +1391,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.0.tgz",
-      "integrity": "sha512-s2Nk6ec+pmYmAb/utawuURy7uvyYKDk+TRE5aqLRsdnj3AhwC9IKUBmhfnLmY/+P+DnwqpeXEFIKe9tlG0p6CA==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.2.tgz",
+      "integrity": "sha512-2DjnmR6JHK4X+dgTXt5/sOCu/7yPtqpYt8s8hLkHFK3MGkka2snTv3yRMdHvuRtJVkPwCGsvBSwmoQCHatauFQ==",
       "cpu": [
         "x64"
       ],
@@ -1407,9 +1407,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.0.tgz",
-      "integrity": "sha512-mGlPJMZReU4yP5fSHjOxiTYvZmwPSWn/eF/dcg21pwfmiUCKS1amFvf1F1RkLHPIMPfocxLViNWFvkvDB14Isg==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.2.tgz",
+      "integrity": "sha512-3j7SWDBS2Wov/L9q0mFJtEvQ5miIqfO4l7d2m9Mo06ddsgUK8gWfHGgbjdFlCp2Ek7MmMQZSxpGFqcC8zGh2AA==",
       "cpu": [
         "arm64"
       ],
@@ -1423,9 +1423,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.0.tgz",
-      "integrity": "sha512-biWqIOE17OW/6S34t1X8K/3vb1+svp5ji5QQT/IKR+VfM3B7GvlCwmz5XtlEan2ukOUf9tj2vJJBffaGH4fGRw==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.2.tgz",
+      "integrity": "sha512-s6N8k8dF9YGc5T01UPQ08yxsK6fUow5gG1/axWc1HVVBYQBgOjca4oUZF7s4p+kwhkB1bDSGR8QznWrFZ/Rt5g==",
       "cpu": [
         "arm64"
       ],
@@ -1439,9 +1439,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.0.tgz",
-      "integrity": "sha512-zPisT+obYypM/l6EZ0yRkK3LEuoZqHaSoYKj+5jiD9ESHwdr6QhnabnNxYkdy34uCigNlWIaCbjFmQ8FY5AlxA==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.2.tgz",
+      "integrity": "sha512-o1RV/KOODQh6dM6ZRJGZbc+MOAHww33Vbs5JC9Mp1gDk8cpEO+cYC/l7rweiEalkSm5/1WGa4zY7xrNwObN4+Q==",
       "cpu": [
         "x64"
       ],
@@ -1455,9 +1455,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.0.tgz",
-      "integrity": "sha512-+t3+7GoU9IYmk+N+FHKBNFdahaReoAktdOpXHFIPOU1ixxtdge26NgQEEkJkCw2dHT9UwwK5zw4mAsURw4E8jA==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.2.tgz",
+      "integrity": "sha512-/VUnh7w8RElYZ0IV83nUcP/J4KJ6LLYliiBIri3p3aW2giF+PAVgZb6mk8jbQSB3WlTai8gEmCAr7kptFa1H6g==",
       "cpu": [
         "x64"
       ],
@@ -1471,9 +1471,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.0.tgz",
-      "integrity": "sha512-d8MrXKh0A+c9DLiy1BUFwtg3Hu90Lucj3k6iKTUdPOv42Ve2UiIG8HYi3UAb8kFVluXxEfdpCoPPCSODk5fDcw==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.2.tgz",
+      "integrity": "sha512-sMPyTvRcNKXseNQ/7qRfVRLa0VhR0esmQ29DD6pqvG71+JdVnESJaHPA8t7bc67KD5spP3+DOCNLhqlEI2ZgQg==",
       "cpu": [
         "arm64"
       ],
@@ -1487,9 +1487,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.0.tgz",
-      "integrity": "sha512-Fe1tGHxOWEyQjmygWkkXSwhFcTJuimrNu52JEuwItrKJVV4iRjbWp9I7zZjwqtiNnQmxoEvoisn8wueFLrNpvQ==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.2.tgz",
+      "integrity": "sha512-W5VvyZHnxG/2ukhZF/9Ikdra5fdNftxI6ybeVKYvBPDtyx7x4jPPSNduUkfH5fo3zG0JQ0bPxgy41af2JX5D4Q==",
       "cpu": [
         "x64"
       ],
@@ -2979,9 +2979,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.48.1.tgz",
-      "integrity": "sha512-rGmb8qoG/zdmKoYELCBwu7vt+9HxZ7Koos3pD0+sH5fR3u3Wb/jGcpnqxcnWsPEKDUyzeLSqksN8LJtgXjqBYw==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.49.0.tgz",
+      "integrity": "sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==",
       "cpu": [
         "arm"
       ],
@@ -2994,9 +2994,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.48.1.tgz",
-      "integrity": "sha512-4e9WtTxrk3gu1DFE+imNJr4WsL13nWbD/Y6wQcyku5qadlKHY3OQ3LJ/INrrjngv2BJIHnIzbqMk1GTAC2P8yQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.49.0.tgz",
+      "integrity": "sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==",
       "cpu": [
         "arm64"
       ],
@@ -3009,9 +3009,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.48.1.tgz",
-      "integrity": "sha512-+XjmyChHfc4TSs6WUQGmVf7Hkg8ferMAE2aNYYWjiLzAS/T62uOsdfnqv+GHRjq7rKRnYh4mwWb4Hz7h/alp8A==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.49.0.tgz",
+      "integrity": "sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==",
       "cpu": [
         "arm64"
       ],
@@ -3024,9 +3024,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.48.1.tgz",
-      "integrity": "sha512-upGEY7Ftw8M6BAJyGwnwMw91rSqXTcOKZnnveKrVWsMTF8/k5mleKSuh7D4v4IV1pLxKAk3Tbs0Lo9qYmii5mQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.49.0.tgz",
+      "integrity": "sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==",
       "cpu": [
         "x64"
       ],
@@ -3039,9 +3039,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.48.1.tgz",
-      "integrity": "sha512-P9ViWakdoynYFUOZhqq97vBrhuvRLAbN/p2tAVJvhLb8SvN7rbBnJQcBu8e/rQts42pXGLVhfsAP0k9KXWa3nQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.49.0.tgz",
+      "integrity": "sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==",
       "cpu": [
         "arm64"
       ],
@@ -3054,9 +3054,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.48.1.tgz",
-      "integrity": "sha512-VLKIwIpnBya5/saccM8JshpbxfyJt0Dsli0PjXozHwbSVaHTvWXJH1bbCwPXxnMzU4zVEfgD1HpW3VQHomi2AQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.49.0.tgz",
+      "integrity": "sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==",
       "cpu": [
         "x64"
       ],
@@ -3069,9 +3069,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.48.1.tgz",
-      "integrity": "sha512-3zEuZsXfKaw8n/yF7t8N6NNdhyFw3s8xJTqjbTDXlipwrEHo4GtIKcMJr5Ed29leLpB9AugtAQpAHW0jvtKKaQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.49.0.tgz",
+      "integrity": "sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==",
       "cpu": [
         "arm"
       ],
@@ -3084,9 +3084,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.48.1.tgz",
-      "integrity": "sha512-leo9tOIlKrcBmmEypzunV/2w946JeLbTdDlwEZ7OnnsUyelZ72NMnT4B2vsikSgwQifjnJUbdXzuW4ToN1wV+Q==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.49.0.tgz",
+      "integrity": "sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==",
       "cpu": [
         "arm"
       ],
@@ -3099,9 +3099,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.48.1.tgz",
-      "integrity": "sha512-Vy/WS4z4jEyvnJm+CnPfExIv5sSKqZrUr98h03hpAMbE2aI0aD2wvK6GiSe8Gx2wGp3eD81cYDpLLBqNb2ydwQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.49.0.tgz",
+      "integrity": "sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==",
       "cpu": [
         "arm64"
       ],
@@ -3114,9 +3114,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.48.1.tgz",
-      "integrity": "sha512-x5Kzn7XTwIssU9UYqWDB9VpLpfHYuXw5c6bJr4Mzv9kIv242vmJHbI5PJJEnmBYitUIfoMCODDhR7KoZLot2VQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.49.0.tgz",
+      "integrity": "sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==",
       "cpu": [
         "arm64"
       ],
@@ -3129,9 +3129,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.48.1.tgz",
-      "integrity": "sha512-yzCaBbwkkWt/EcgJOKDUdUpMHjhiZT/eDktOPWvSRpqrVE04p0Nd6EGV4/g7MARXXeOqstflqsKuXVM3H9wOIQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.49.0.tgz",
+      "integrity": "sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==",
       "cpu": [
         "loong64"
       ],
@@ -3144,9 +3144,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.48.1.tgz",
-      "integrity": "sha512-UK0WzWUjMAJccHIeOpPhPcKBqax7QFg47hwZTp6kiMhQHeOYJeaMwzeRZe1q5IiTKsaLnHu9s6toSYVUlZ2QtQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.49.0.tgz",
+      "integrity": "sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==",
       "cpu": [
         "ppc64"
       ],
@@ -3159,9 +3159,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.48.1.tgz",
-      "integrity": "sha512-3NADEIlt+aCdCbWVZ7D3tBjBX1lHpXxcvrLt/kdXTiBrOds8APTdtk2yRL2GgmnSVeX4YS1JIf0imFujg78vpw==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.49.0.tgz",
+      "integrity": "sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==",
       "cpu": [
         "riscv64"
       ],
@@ -3174,9 +3174,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.48.1.tgz",
-      "integrity": "sha512-euuwm/QTXAMOcyiFCcrx0/S2jGvFlKJ2Iro8rsmYL53dlblp3LkUQVFzEidHhvIPPvcIsxDhl2wkBE+I6YVGzA==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.49.0.tgz",
+      "integrity": "sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==",
       "cpu": [
         "riscv64"
       ],
@@ -3189,9 +3189,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.48.1.tgz",
-      "integrity": "sha512-w8mULUjmPdWLJgmTYJx/W6Qhln1a+yqvgwmGXcQl2vFBkWsKGUBRbtLRuKJUln8Uaimf07zgJNxOhHOvjSQmBQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.49.0.tgz",
+      "integrity": "sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==",
       "cpu": [
         "s390x"
       ],
@@ -3204,9 +3204,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.48.1.tgz",
-      "integrity": "sha512-90taWXCWxTbClWuMZD0DKYohY1EovA+W5iytpE89oUPmT5O1HFdf8cuuVIylE6vCbrGdIGv85lVRzTcpTRZ+kA==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.49.0.tgz",
+      "integrity": "sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==",
       "cpu": [
         "x64"
       ],
@@ -3219,9 +3219,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.48.1.tgz",
-      "integrity": "sha512-2Gu29SkFh1FfTRuN1GR1afMuND2GKzlORQUP3mNMJbqdndOg7gNsa81JnORctazHRokiDzQ5+MLE5XYmZW5VWg==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.49.0.tgz",
+      "integrity": "sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==",
       "cpu": [
         "x64"
       ],
@@ -3234,9 +3234,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.48.1.tgz",
-      "integrity": "sha512-6kQFR1WuAO50bxkIlAVeIYsz3RUx+xymwhTo9j94dJ+kmHe9ly7muH23sdfWduD0BA8pD9/yhonUvAjxGh34jQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.49.0.tgz",
+      "integrity": "sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==",
       "cpu": [
         "arm64"
       ],
@@ -3249,9 +3249,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.48.1.tgz",
-      "integrity": "sha512-RUyZZ/mga88lMI3RlXFs4WQ7n3VyU07sPXmMG7/C1NOi8qisUg57Y7LRarqoGoAiopmGmChUhSwfpvQ3H5iGSQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.49.0.tgz",
+      "integrity": "sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==",
       "cpu": [
         "ia32"
       ],
@@ -3264,9 +3264,9 @@
       "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.48.1.tgz",
-      "integrity": "sha512-8a/caCUN4vkTChxkaIJcMtwIVcBhi4X2PQRoT+yCK3qRYaZ7cURrmJFL5Ux9H9RaMIXj9RuihckdmkBX3zZsgg==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.49.0.tgz",
+      "integrity": "sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==",
       "cpu": [
         "x64"
       ],
@@ -5572,12 +5572,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.0.tgz",
-      "integrity": "sha512-N1lp9Hatw3a9XLt0307lGB4uTKsXDhyOKQo7uYMzX4i0nF/c27grcGXkLdb7VcT8QPYLBa8ouIyEoUQJ2OyeNQ==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.2.tgz",
+      "integrity": "sha512-H8Otr7abj1glFhbGnvUt3gz++0AF1+QoCXEBmd/6aKbfdFwrn0LpA836Ed5+00va/7HQSDD+mOoVhn3tNy3e/Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.0",
+        "@next/env": "15.5.2",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -5590,14 +5590,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.0",
-        "@next/swc-darwin-x64": "15.5.0",
-        "@next/swc-linux-arm64-gnu": "15.5.0",
-        "@next/swc-linux-arm64-musl": "15.5.0",
-        "@next/swc-linux-x64-gnu": "15.5.0",
-        "@next/swc-linux-x64-musl": "15.5.0",
-        "@next/swc-win32-arm64-msvc": "15.5.0",
-        "@next/swc-win32-x64-msvc": "15.5.0",
+        "@next/swc-darwin-arm64": "15.5.2",
+        "@next/swc-darwin-x64": "15.5.2",
+        "@next/swc-linux-arm64-gnu": "15.5.2",
+        "@next/swc-linux-arm64-musl": "15.5.2",
+        "@next/swc-linux-x64-gnu": "15.5.2",
+        "@next/swc-linux-x64-musl": "15.5.2",
+        "@next/swc-win32-arm64-msvc": "15.5.2",
+        "@next/swc-win32-x64-msvc": "15.5.2",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -6402,9 +6402,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.48.1.tgz",
-      "integrity": "sha512-jVG20NvbhTYDkGAty2/Yh7HK6/q3DGSRH4o8ALKGArmMuaauM9kLfoMZ+WliPwA5+JHr2lTn3g557FxBV87ifg==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
+      "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6419,26 +6419,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.48.1",
-        "@rollup/rollup-android-arm64": "4.48.1",
-        "@rollup/rollup-darwin-arm64": "4.48.1",
-        "@rollup/rollup-darwin-x64": "4.48.1",
-        "@rollup/rollup-freebsd-arm64": "4.48.1",
-        "@rollup/rollup-freebsd-x64": "4.48.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.48.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.48.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.48.1",
-        "@rollup/rollup-linux-arm64-musl": "4.48.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.48.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.48.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.48.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.48.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.48.1",
-        "@rollup/rollup-linux-x64-gnu": "4.48.1",
-        "@rollup/rollup-linux-x64-musl": "4.48.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.48.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.48.1",
-        "@rollup/rollup-win32-x64-msvc": "4.48.1",
+        "@rollup/rollup-android-arm-eabi": "4.49.0",
+        "@rollup/rollup-android-arm64": "4.49.0",
+        "@rollup/rollup-darwin-arm64": "4.49.0",
+        "@rollup/rollup-darwin-x64": "4.49.0",
+        "@rollup/rollup-freebsd-arm64": "4.49.0",
+        "@rollup/rollup-freebsd-x64": "4.49.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.49.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.49.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.49.0",
+        "@rollup/rollup-linux-arm64-musl": "4.49.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.49.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.49.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.49.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.49.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.49.0",
+        "@rollup/rollup-linux-x64-gnu": "4.49.0",
+        "@rollup/rollup-linux-x64-musl": "4.49.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.49.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.49.0",
+        "@rollup/rollup-win32-x64-msvc": "4.49.0",
         "fsevents": "~2.3.2"
       }
     },

--- a/src/components/admin/ServiceForm.tsx
+++ b/src/components/admin/ServiceForm.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Service } from '@prisma/client';
+import { useRouter } from 'next/navigation';
+
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { toast } from 'sonner';
+
+const serviceFormSchema = z.object({
+  name: z.string().min(2, {
+    message: 'Name must be at least 2 characters.',
+  }),
+  duration: z.coerce.number().int().positive({
+    message: 'Duration must be a positive number.',
+  }),
+  price: z.coerce.number().int().min(0, {
+    message: 'Price cannot be negative.',
+  }),
+  active: z.boolean(),
+});
+
+type ServiceFormValues = z.infer<typeof serviceFormSchema>;
+
+interface ServiceFormProps {
+  service?: Service;
+  onClose: () => void;
+}
+
+export function ServiceForm({ service, onClose }: ServiceFormProps) {
+  const router = useRouter();
+  const form = useForm<ServiceFormValues>({
+    resolver: zodResolver(serviceFormSchema),
+    defaultValues: {
+      name: service?.name || '',
+      duration: service?.duration || 30,
+      price: service?.price || 0,
+      active: service?.active ?? true,
+    },
+  });
+
+  const onSubmit = async (data: ServiceFormValues) => {
+    const method = service ? 'PUT' : 'POST';
+    const url = service
+      ? `/api/admin/services/${service.id}`
+      : '/api/admin/services';
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to ${service ? 'update' : 'create'} service`);
+      }
+
+      toast.success(
+        `Dienstleistung ${service ? 'erfolgreich aktualisiert' : 'erfolgreich erstellt'}.`
+      );
+      router.refresh();
+      onClose();
+    } catch (error) {
+      console.error('Error saving service:', error);
+      toast.error('Ein Fehler ist aufgetreten.');
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input placeholder="z.B. Herrenhaarschnitt" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="duration"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Dauer (in Minuten)</FormLabel>
+              <FormControl>
+                <Input type="number" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="price"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Preis (in Rappen/Cent)</FormLabel>
+              <FormControl>
+                <Input type="number" {...field} />
+              </FormControl>
+              <FormDescription>
+                Geben Sie den Preis in der kleinsten Währungseinheit an (z.B. 5000 für 50.00 CHF).
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="active"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <FormLabel>Aktiv</FormLabel>
+                <FormDescription>
+                  Macht die Dienstleistung für Kunden buchbar.
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end space-x-2">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting ? 'Speichern...' : 'Speichern'}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/admin/ServicesClient.tsx
+++ b/src/components/admin/ServicesClient.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState } from 'react';
+import { PlusCircle } from 'lucide-react';
+import { Service } from '@prisma/client';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { ServiceForm } from './ServiceForm';
+
+interface ServicesClientProps {
+  services: Service[];
+}
+
+export function ServicesClient({ services }: ServicesClientProps) {
+  const router = useRouter();
+  const [isAddDialogOpen, setAddDialogOpen] = useState(false);
+  const [editingService, setEditingService] = useState<Service | null>(null);
+  const [deletingService, setDeletingService] = useState<Service | null>(null);
+
+  const formatPrice = (priceInCents: number) => {
+    return (priceInCents / 100).toFixed(2);
+  };
+
+  const handleEditClick = (service: Service) => {
+    setEditingService(service);
+  };
+
+  const handleCloseEditDialog = () => {
+    setEditingService(null);
+  };
+
+  const handleDeleteClick = (service: Service) => {
+    setDeletingService(service);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deletingService) return;
+
+    try {
+      const response = await fetch(`/api/admin/services/${deletingService.id}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to delete service');
+      }
+
+      toast.success('Dienstleistung erfolgreich gelöscht.');
+      router.refresh();
+      setDeletingService(null);
+    } catch (error) {
+      console.error('Error deleting service:', error);
+      toast.error('Ein Fehler ist aufgetreten.');
+      setDeletingService(null);
+    }
+  };
+
+  return (
+    <>
+      <div className="p-4 sm:p-6">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <CardTitle>Dienstleistungen</CardTitle>
+              <CardDescription>
+                Verwalten Sie hier Ihre Dienstleistungen.
+              </CardDescription>
+            </div>
+            <Dialog open={isAddDialogOpen} onOpenChange={setAddDialogOpen}>
+              <DialogTrigger asChild>
+                <Button>
+                  <PlusCircle className="mr-2 h-4 w-4" />
+                  Neue Dienstleistung
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Neue Dienstleistung erstellen</DialogTitle>
+                </DialogHeader>
+                <ServiceForm onClose={() => setAddDialogOpen(false)} />
+              </DialogContent>
+            </Dialog>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead className="text-right">Dauer (Min)</TableHead>
+                  <TableHead className="text-right">Preis (CHF)</TableHead>
+                  <TableHead>
+                    <span className="sr-only">Aktionen</span>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {services.map((service) => (
+                  <TableRow key={service.id}>
+                    <TableCell>
+                      <Badge variant={service.active ? 'default' : 'secondary'}>
+                        {service.active ? 'Aktiv' : 'Inaktiv'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-medium">{service.name}</TableCell>
+                    <TableCell className="text-right">{service.duration}</TableCell>
+                    <TableCell className="text-right">
+                      {formatPrice(service.price)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button variant="ghost" size="sm" onClick={() => handleEditClick(service)}>
+                        Bearbeiten
+                      </Button>
+                      <Button variant="ghost" size="sm" className="text-red-500 hover:text-red-600" onClick={() => handleDeleteClick(service)}>
+                        Löschen
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {services.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center">
+                      Keine Dienstleistungen gefunden.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        {/* Edit Service Dialog */}
+        <Dialog open={!!editingService} onOpenChange={(open) => !open && handleCloseEditDialog()}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Dienstleistung bearbeiten</DialogTitle>
+            </DialogHeader>
+            {editingService && (
+              <ServiceForm
+                service={editingService}
+                onClose={handleCloseEditDialog}
+              />
+            )}
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={!!deletingService} onOpenChange={(open) => !open && setDeletingService(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Sind Sie sicher?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Diese Aktion kann nicht rückgängig gemacht werden. Dies wird die
+              Dienstleistung &quot;{deletingService?.name}&quot; dauerhaft löschen.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setDeletingService(null)}>Abbrechen</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmDelete}>Löschen</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}


### PR DESCRIPTION
This commit introduces the initial implementation of the admin dashboard, focusing on the management of services.

A new route group `(admin)` is created with a dedicated layout at `app/(admin)/layout.tsx`. This layout includes a persistent sidebar for navigation, built with the existing `sidebar.tsx` component.

The main feature is the service management page at `app/(admin)/services/page.tsx`. This page fetches the list of services on the server and uses a client component, `ServicesClient.tsx`, to render the UI and handle user interactions.

Full CRUD (Create, Read, Update, Delete) functionality for services is implemented:
- A reusable `ServiceForm.tsx` component handles the logic for both creating and updating services, including form validation with Zod.
- Dialogs (`Dialog` and `AlertDialog`) are used to provide a non-disruptive user experience for adding, editing, and deleting services.
- All actions communicate with the existing backend API endpoints under `/api/admin/services`.
- The UI provides feedback on operations via toast notifications.